### PR TITLE
Fix git user home location to match Gitlab expectations

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -51,14 +51,14 @@ echo 'unixsocketperm 770' >> /usr/local/etc/redis.conf
 service redis start
 pw groupmod redis -m git
 
-# gitlab *really* wants things in /usr/home
-mkdir -p /usr/home/git
+# gitlab *really* wants things in /usr/local
+mkdir -p /usr/local/git
 
-# Set git users home to /home/git
-pw usermod git -d /usr/home/git
+# Set git users home to /local/git
+pw usermod git -d /usr/local/git
 
 # Make sure the .ssh dir exists
-su -l git -c "mkdir -p /usr/home/git/.ssh"
+su -l git -c "mkdir -p /usr/local/git/.ssh"
 
 # Set the hostname for gitlab instance
 if [ -n "$IOCAGE_PLUGIN_IP" ] ; then


### PR DESCRIPTION
Spawned from the following help topic: https://www.ixsystems.com/community/threads/gitlab-plugin-registered-ssh-keys-not-accepted.76447/#post-531568

It seems as though the home user directory configured by post_install.sh does not match the expected home directory used by Gitlab. This PR corrects the script to ensure that the SSHD configuration works correctly.