### PR TITLE
fix issue 12

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -23,20 +23,21 @@ cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1 > /root/dbpasswor
 PASS=`cat /root/dbpassword`
 
 # create user git
-psql -d template1 -U pgsql -c "CREATE USER ${USER} CREATEDB SUPERUSER;"
+psql -d template1 -U postgres -c "CREATE USER ${USER} CREATEDB SUPERUSER;"
 
 # Create the GitLab production database & grant all privileges on database
-psql -d template1 -U pgsql -c "CREATE DATABASE ${DB} OWNER ${USER};"
+psql -d template1 -U postgres -c "CREATE DATABASE ${DB} OWNER ${USER};"
 
 # Set a password on the postgres account
-psql -d template1 -U pgsql -c "ALTER USER ${USER} WITH PASSWORD '${PASS}';"
+psql -d template1 -U postgres -c "ALTER USER ${USER} WITH PASSWORD '${PASS}';"
 
 # Connect as superuser to gitlab db and enable pg_trgm extension
-psql -U pgsql -d ${DB} -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+psql -U postgres -d ${DB} -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+psql -U postgres -d ${DB} -c "CREATE EXTENSION IF NOT EXISTS btree_gist;"
 
 # Fix permission for postgres 
-echo "listen_addresses = '*'" >> /usr/local/pgsql/data/postgresql.conf
-echo "host  all  all 0.0.0.0/0 md5" >> /usr/local/pgsql/data/pg_hba.conf
+echo "listen_addresses = '*'" >> /var/db/postgres/data13/postgresql.conf
+echo "host  all  all 0.0.0.0/0 md5" >> /var/db/postgres/data13/pg_hba.conf
 
 # Restart postgresql after config change
 service postgresql restart
@@ -88,7 +89,7 @@ su -l git -c "cd /usr/local/www/gitlab-ce && echo "yes" | rake gitlab:setup RAIL
 su -l git -c "cd /usr/local/www/gitlab-ce && rake gettext:compile RAILS_ENV=production"
 
 #Workaround to fix fetch failers
-su -l git -c "cd /usr/local/www/gitlab-ce && rake yarn:install --har RAILS_ENV=production NODE_ENV=production"
+su -l git -c "cd /usr/local/www/gitlab-ce && rake yarn:install RAILS_ENV=production NODE_ENV=production"
 
 # Update node dependencies and recompile assets
 su -l git -c "cd /usr/local/www/gitlab-ce && rake yarn:install gitlab:assets:clean gitlab:assets:compile RAILS_ENV=production NODE_ENV=production"


### PR DESCRIPTION
This merge request fixes the following problems mentioned in [this comment](https://github.com/freenas/iocage-plugin-gitlab/issues/12#issuecomment-1004318242) of [issue 12](https://github.com/freenas/iocage-plugin-gitlab/issues/12):
1. change psql database username from pgsql into the new default username postgres
2. changed the path to postgresql.conf
3. removed the `--har` option from `yarn install`, this option doesn't seem to work anymore. According to the [yarn install documentation](https://classic.yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-har) it seems to create a HTTP archive. It seems this archive is not required to install the plugin.

Additional changes:
- added Postgres extension btree_gist. I read somewhere this extension is required. I don't know for sure.

The [minimum PostgreSQL version](https://docs.gitlab.com/ee/install/requirements.html#postgresql-requirements) supported by Gitlab v14 is version 12. Somewhere (I cannot remember where) I read it the default Postgres version (on Freebsd?) is v13. This fix changes the Postgres database from v12 to v13. I tested this fix on release 12.3-RELEASE Freebsd jail. The original [gitlab.json](https://github.com/ix-plugin-hub/iocage-plugin-index/blob/master/gitlab.json) plugin requires 12.2-RELEASE. I believe this plugin has to change too?


@william-gr or @miwi-fbsd could you please have a look at this pull request and merge the fix? Thanks